### PR TITLE
Add native arm64 macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ SharpEyes is organized into five tabs, each corresponding to a stage of processi
 
 ## Installation
 
-Executables and installers are available on the [Releases page](https://github.com/gallantlab/SharpEyes/releases). Windows has both a standalone `.exe` and an installer. Linux has a standalone `.exe`; additional system libraries may be required and SharpEyes will report any that are missing. macOS is not supported.
+Executables and installers are available on the [Releases page](https://github.com/gallantlab/SharpEyes/releases). Windows has both a standalone `.exe` and an installer. Linux has a standalone `.exe`; additional system libraries may be required and SharpEyes will report any that are missing. macOS (Apple Silicon / arm64) is supported and builds from source; see below.
 
 ## Requirements
 
-This is targeted at .NET 10 on Window 10/11 (though I see no reason why it shouldn't work down to Windows 7) and Ubuntu 24 (some fudging might be needed to get OpenCVSharp working on other versions)
+This is targeted at .NET 10 on Window 10/11 (though I see no reason why it shouldn't work down to Windows 7) and Ubuntu 24 (some fudging might be needed to get OpenCVSharp working on other versions).
+
+macOS support targets Apple Silicon (arm64) on .NET 10. The OpenCvSharp native runtime is bundled via NuGet, so no separate OpenCV install is needed. Note that Eyelink `.edf` import is unavailable on macOS (SR Research does not ship the `edfapi` library for macOS); NumPy and CSV gaze import work as normal.
 
 If you would like to do things to the code, this is written using Visual Studio (not code) and Jetbrains Rider.
 

--- a/SharpEyes/Models/PythonEnvironmentManager.cs
+++ b/SharpEyes/Models/PythonEnvironmentManager.cs
@@ -51,7 +51,9 @@ namespace SharpEyes.Models
 				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 					platform = "x86_64-pc-windows-msvc";
 				else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-					platform = "aarch64-apple-darwin";
+					platform = RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+						? "aarch64-apple-darwin"
+						: "x86_64-apple-darwin";
 				else
 					platform = "x86_64-unknown-linux-gnu";
 				return String.Format(

--- a/SharpEyes/Models/PythonEnvironmentManager.cs
+++ b/SharpEyes/Models/PythonEnvironmentManager.cs
@@ -47,9 +47,13 @@ namespace SharpEyes.Models
 		{
 			get
 			{
-				string platform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-					? "x86_64-pc-windows-msvc"
-					: "x86_64-unknown-linux-gnu";
+				string platform;
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+					platform = "x86_64-pc-windows-msvc";
+				else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+					platform = "aarch64-apple-darwin";
+				else
+					platform = "x86_64-unknown-linux-gnu";
 				return String.Format(
 					"https://github.com/indygreg/python-build-standalone/releases/download/{0}/cpython-{1}+{0}-{2}-install_only_stripped.tar.gz",
 					BundledPythonTag, BundledPythonVersion, platform);
@@ -136,6 +140,15 @@ namespace SharpEyes.Models
 				{
 					if (!Directory.Exists(dir)) continue;
 					string[] candidates = Directory.GetFiles(dir, "libpython3.*.so.1.0");
+					if (candidates.Length > 0) return candidates[0];
+				}
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			{
+				string libDir = Path.Combine(pythonHome, "lib");
+				if (Directory.Exists(libDir))
+				{
+					string[] candidates = Directory.GetFiles(libDir, "libpython3.*.dylib");
 					if (candidates.Length > 0) return candidates[0];
 				}
 			}

--- a/SharpEyes/SharpEyes.csproj
+++ b/SharpEyes/SharpEyes.csproj
@@ -24,7 +24,8 @@
   <ItemGroup>
     <PackageReference Include="alglib.net" Version="3.18.2" />
     <PackageReference Include="pythonnet" Version="3.0.4" />
-    <PackageReference Include="OpenCvSharp4.official.runtime.ubuntu.24.04-x64" Version="4.13.0.20260308" />
+    <PackageReference Include="OpenCvSharp4.official.runtime.ubuntu.24.04-x64" Version="4.13.0.20260308" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="OneWare.OpenCvSharp4.runtime.osx-arm64" Version="4.13.0.18" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
     <PackageReference Include="SkiaSharp" Version="2.88.9" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="System.Formats.Nrbf" Version="10.0.8" />
@@ -37,10 +38,10 @@
     <PackageReference Include="MessageBox.Avalonia" Version="2.1.0" />
     <PackageReference Include="NumSharp" Version="0.30.0" />
     <PackageReference Include="OpenCvSharp4" Version="4.13.0.20260427" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.13.0.20260302" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.13.0.20260302" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="Sentry" Version="3.21.0" />
     <PackageReference Include="Tmds.DBus" Version="0.92.0" />
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.17.4" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.17.4" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpEyes/SharpEyes.csproj
+++ b/SharpEyes/SharpEyes.csproj
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="alglib.net" Version="3.18.2" />
     <PackageReference Include="pythonnet" Version="3.0.4" />
-    <PackageReference Include="OpenCvSharp4.official.runtime.ubuntu.24.04-x64" Version="4.13.0.20260308" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="OneWare.OpenCvSharp4.runtime.osx-arm64" Version="4.13.0.18" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="OpenCvSharp4.official.runtime.ubuntu.24.04-x64" Version="4.13.0.20260308" />
+    <PackageReference Include="OneWare.OpenCvSharp4.runtime.osx-arm64" Version="4.13.0.18" />
     <PackageReference Include="SkiaSharp" Version="2.88.9" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="System.Formats.Nrbf" Version="10.0.8" />
@@ -38,10 +38,10 @@
     <PackageReference Include="MessageBox.Avalonia" Version="2.1.0" />
     <PackageReference Include="NumSharp" Version="0.30.0" />
     <PackageReference Include="OpenCvSharp4" Version="4.13.0.20260427" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.13.0.20260302" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.13.0.20260302" />
     <PackageReference Include="Sentry" Version="3.21.0" />
     <PackageReference Include="Tmds.DBus" Version="0.92.0" />
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.17.4" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.17.4" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/building.md
+++ b/docs/building.md
@@ -77,15 +77,27 @@ arm64 Mac.
 ## Building on Windows and Linux
 
 The project is developed with Visual Studio (not VS Code) and JetBrains Rider.
-You can also build from the command line:
+You can also build Windows from the command line:
 
 ```bash
 # Windows
 dotnet build SharpEyes/SharpEyes.csproj -c Release -r win-x64
-
-# Linux (Ubuntu 24)
-dotnet build SharpEyes/SharpEyes.csproj -c Release -r linux-x64
 ```
 
-The correct OpenCvSharp native runtime for each platform is selected
-automatically based on the build target.
+### Linux runtime identifier
+
+Build Linux on an Ubuntu 24 host with the distro-specific RID, **not** the
+portable `linux-x64`:
+
+```bash
+dotnet build SharpEyes/SharpEyes.csproj -c Release -r ubuntu.24.04-x64
+```
+
+The project references `OpenCvSharp4.official.runtime.ubuntu.24.04-x64`, whose
+package ships `libOpenCvSharpExtern.so` only under `runtimes/ubuntu.24.04-x64/`.
+The .NET RID graph does not fall forward from the generic `linux-x64` to that
+asset, so a `linux-x64` build compiles successfully but ships **without** the
+native library and crashes when OpenCV is first used. The csproj sets
+`<UseRidGraph>true</UseRidGraph>` so the distro RID is available. Note that the
+SDK may only recognize `ubuntu.24.04-x64` when building on a matching Linux
+host; cross-building this RID from Windows or macOS is not supported.

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,91 @@
+# Building from source
+
+SharpEyes is a .NET 10 application. On Windows and Linux it is typically built
+with Visual Studio or JetBrains Rider, but it can also be built from the command
+line with the .NET SDK on any supported platform — including macOS.
+
+## Building on macOS (Apple Silicon / arm64)
+
+These steps produce a native arm64 build. No Homebrew OpenCV install is required:
+the OpenCvSharp native runtime is pulled in automatically as a NuGet package.
+
+### 1. Install the .NET 10 SDK
+
+Download the **arm64** .NET 10 SDK from
+[dotnet.microsoft.com](https://dotnet.microsoft.com/download/dotnet/10.0) and run
+the installer. Verify the install:
+
+```bash
+dotnet --version        # should print 10.0.xxx
+dotnet --list-sdks      # should list a 10.0.x SDK
+```
+
+The installer puts `dotnet` at `/usr/local/share/dotnet/dotnet`. If `dotnet` is
+not found in your shell, add it to your `PATH`:
+
+```bash
+echo 'export PATH="/usr/local/share/dotnet:$PATH"' >> ~/.zshrc
+```
+
+### 2. Clone and build
+
+```bash
+git clone https://github.com/gallantlab/SharpEyes.git
+cd SharpEyes
+dotnet build SharpEyes/SharpEyes.csproj -c Debug -r osx-arm64
+```
+
+Run it directly with:
+
+```bash
+dotnet run --project SharpEyes/SharpEyes.csproj
+```
+
+### 3. Produce a self-contained build for distribution
+
+To create a standalone folder that bundles the .NET runtime (so the target Mac
+does not need .NET installed):
+
+```bash
+dotnet publish SharpEyes/SharpEyes.csproj \
+  -c Release -r osx-arm64 --self-contained true \
+  -p:PublishSingleFile=false
+```
+
+The output lands in `SharpEyes/bin/Release/net10.0/osx-arm64/publish/`. Launch
+the `SharpEyes` executable there, or zip the `publish` folder to copy to another
+arm64 Mac.
+
+!!! note "Gatekeeper on other Macs"
+    The build is unsigned. It runs fine on the machine that built it, but another
+    Mac will block it on first launch. The user can right-click the executable and
+    choose **Open** once to allow it. Distributing to others without that step
+    requires code signing and notarization with an Apple Developer account.
+
+### macOS notes and limitations
+
+- **OpenCV**: provided by the `OneWare.OpenCvSharp4.runtime.osx-arm64` NuGet
+  package; the native `libOpenCvSharpExtern.dylib` is self-contained, so no
+  separate OpenCV install is needed.
+- **Eyelink `.edf` import is unavailable**: SR Research does not ship the
+  `edfapi` library for macOS. SharpEyes detects this and disables EDF parsing;
+  NumPy and CSV gaze import still work.
+- **Intel (x86_64) Macs / Rosetta**: not built or tested here. The same approach
+  works by publishing with `-r osx-x64` and using the `osx-x64` OpenCvSharp
+  runtime package instead, but this is unsupported.
+
+## Building on Windows and Linux
+
+The project is developed with Visual Studio (not VS Code) and JetBrains Rider.
+You can also build from the command line:
+
+```bash
+# Windows
+dotnet build SharpEyes/SharpEyes.csproj -c Release -r win-x64
+
+# Linux (Ubuntu 24)
+dotnet build SharpEyes/SharpEyes.csproj -c Release -r linux-x64
+```
+
+The correct OpenCvSharp native runtime for each platform is selected
+automatically based on the build target.

--- a/docs/getting started.md
+++ b/docs/getting started.md
@@ -14,7 +14,7 @@ A standalone executable is available. Linux may require additional system librar
 
 ### macOS
 
-I have no macOS development environment, so it's not supported. But because all the packages here are cross-platform, I see no reason why it can't be compiled from source on a mac. However, I can't provide any support for that.
+macOS on Apple Silicon (arm64) is supported and built from source — see [Building from source](building.md). Prebuilt executables are not currently published for macOS, so you compile it yourself with the .NET SDK. Note that Eyelink `.edf` import is unavailable on macOS (SR Research does not ship the `edfapi` library for macOS); NumPy and CSV gaze import work normally.
 
 ## Python interop setup
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -28,6 +28,7 @@ extra_css = ["stylesheets/extra.css"]
 nav = [
   {"Home" = "index.md"},
   {"Getting Started" = "getting started.md"},
+  {"Building from source" = "building.md"},
   {"Workflow" = [
     "workflow/index.md",
     "workflow/pupil finding.md",


### PR DESCRIPTION
## Summary

Adds native Apple Silicon (arm64) macOS support to SharpEyes. The app previously built for Windows and Linux only; macOS was documented as unsupported. The only hard blocker was the OpenCvSharp native runtime — the official shimat macOS runtime stalls at 4.6, but the project pins OpenCvSharp 4.13. The community `OneWare.OpenCvSharp4.runtime.osx-arm64` package publishes a matching `4.13.0.18` native runtime, so macOS support reduces to a few small, low-risk changes.

## What changed

- **`SharpEyes/SharpEyes.csproj`**: made the Windows and Linux OpenCvSharp native runtimes OS-conditional, added `OneWare.OpenCvSharp4.runtime.osx-arm64` (4.13.0.18) for macOS, and conditioned the unused `VideoLAN.LibVLC.Windows` reference to Windows only.
- **`SharpEyes/Models/PythonEnvironmentManager.cs`**: added a macOS branch to the bundled-Python download URL (`aarch64-apple-darwin`) and to `FindPythonDLL` (searches `lib/libpython3.*.dylib`). The other Python path helpers already worked on macOS via their existing non-Windows branches.
- **Docs**: new `docs/building.md` ("Building from source") with macOS build/publish steps; updated `docs/getting started.md` and `README.md` to note macOS support; registered the new page in `zensical.toml` nav.

## Why

The native arm64 OpenCvSharp runtime now exists at the exact pinned version, making a native build the least-effort path (no Rosetta, no Homebrew OpenCV — the `libOpenCvSharpExtern.dylib` is self-contained).

## Notes for reviewers

- Managed/native OpenCvSharp version parity: managed `OpenCvSharp4` is `4.13.0.20260427`; OneWare's native build number is `4.13.0.18`. They are ABI-compatible within 4.13.x; if a `VideoCapture` call ever fails to load the native lib, the fix is to align all platforms onto the `OneWare.OpenCvSharp4.runtime.*` set (all exist at 4.13.0.18).
- **Eyelink `.edf` import is unavailable on macOS** by design — SR Research ships no `edfapi` for macOS. `EyelinkParser` detects this via `NativeLibrary.TryLoad` and degrades gracefully; NumPy/CSV gaze import is unaffected.
- The osx-x64 (Rosetta) path is not built or tested, but the equivalent OneWare `osx-x64` package exists if it's ever wanted.

## Test plan

- [x] `dotnet build SharpEyes/SharpEyes.csproj -r osx-arm64` — 0 errors (pre-existing nullable warnings only)
- [x] `dotnet publish -c Release -r osx-arm64 --self-contained` produces a self-contained bundle; `libOpenCvSharpExtern.dylib` is arm64 and statically linked (no external OpenCV deps)
- [x] App launches on macOS (Avalonia UI renders)
- [ ] End-to-end runtime paths pending eyetracking data: video load (OpenCvSharp native) and Motion-Energy with bundled Python (download URL + dylib discovery + pythonnet init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)